### PR TITLE
Make navbar links readble over the "sail" image

### DIFF
--- a/static/src/scss/apps/_eldan.scss
+++ b/static/src/scss/apps/_eldan.scss
@@ -66,6 +66,14 @@ body {
             margin-left: 0;
           }
         }
+
+        .nav-item {
+          z-index: 2;
+        }
+
+        .nav-link {
+          text-shadow: 1px 1px 2px #1d76bd;
+        }
       }
     }
 


### PR DESCRIPTION
Which appears when container width is near the
media query breakpoints