### PR TITLE
Improve support for small screen sizes for homepage sponsors

### DIFF
--- a/ilpycon/templates/homepage_sponsors.html
+++ b/ilpycon/templates/homepage_sponsors.html
@@ -13,16 +13,18 @@
         <div class="col-3 sponsor-name">
           <h3>{{ sponsor_level.name }}</h3>
         </div>
-        <div class="col-9 sponsor-logos">
+        <div class="col">
+        <div class="row sponsor-logos">
         {% sponsors sponsor_level.name as level_sponsors %}
         {% for sponsor in level_sponsors %}
-          <div class="sponsor-logo">
+          <div class="col sponsor-logo">
             <a href="{{ sponsor.external_url }}" title="{{ sponsor.name }}">
               {% thumbnail sponsor.website_logo '300x300' as icon %} {# Set size according to level? #}
               <img src="{{ icon|data_uri }}" alt="{{ sponsor.name }}">
             </a>
           </div>
         {% endfor %}
+      </div>
       </div>
     </div>  
     {% endif %}  

--- a/static/src/scss/apps/_sponsors.scss
+++ b/static/src/scss/apps/_sponsors.scss
@@ -11,7 +11,7 @@
     }
     .row { margin-top: 2em; }
     .sponsor-name {
-        text-align: right;
+        text-align: end;
     }
     .sponsor-logos {
         display: flex;


### PR DESCRIPTION
Also minor fix of text alignment

The support of small screens is done by replacing the non-responsive `col-9` containing all the sponsor logos per a level, with a `col` containing a `row` in which each logo is a `col`. This means that, as long as there is room, the level is to-the-side-and-slightly-above the logos, and when there's less room, first the level is stacked over the logos, then the logos are stacked over each other.