### PR TITLE
Fix applicant in sponsors.json

### DIFF
--- a/fixtures/sponsors.json
+++ b/fixtures/sponsors.json
@@ -297,7 +297,7 @@
     "model": "symposion_sponsorship.sponsor",
     "pk": 15,
     "fields": {
-        "applicant": 139,
+        "applicant": 1,
         "name": "Microsoft",
         "display_url": "",
         "external_url": "https://www.microsoft.com/",


### PR DESCRIPTION
If the applicant is not an existing user, it will fail to load the sponsors.